### PR TITLE
fix compatibility with PHP 8

### DIFF
--- a/README
+++ b/README
@@ -16,12 +16,12 @@ You can use it to:
 - much more
 
 All API methods are fully documented at https://telerivet.com/api/rest/php ,
-as well as in the comments of the PHP source files. To learn what functionality is available, 
+as well as in the comments of the PHP source files. To learn what functionality is available,
 start with telerivet.php, lib/project.php, and lib/apicursor.php .
 
 System Requirements:
 --------------------
-PHP 5.3 or higher
+PHP 7.0 or higher (PHP 5.3-5.6 supported by an older version of this library at https://github.com/Telerivet/telerivet-php-client/releases/tag/v1.5.0)
 PHP json extension (usually enabled in PHP by default)
 PHP curl extension (usually enabled in PHP by default)
 
@@ -32,7 +32,7 @@ and require telerivet.php in your PHP code, e.g.:
 
 require_once "path/to/telerivet.php";
 
-Alternatively, if you use Composer for dependency management, 
+Alternatively, if you use Composer for dependency management,
 you can add the following to your composer.json:
 
 "require": {
@@ -43,7 +43,7 @@ Example Usage:
 --------------
 
 require_once "path/to/telerivet.php";
-   
+
 $API_KEY = 'YOUR_API_KEY';           // from https://telerivet.com/api/keys
 $PROJECT_ID = 'YOUR_PROJECT_ID';
 
@@ -55,9 +55,9 @@ $project = $telerivet->initProjectById($PROJECT_ID);
 $project->sendMessage(array(
     'to_number' => '555-0001',
     'content' => 'Hello world!'
-));   
+));
 
-// Query contacts  
+// Query contacts
 $name_prefix = 'John';
 $cursor = $project->queryContacts(array(
     'name[prefix]' => $name_prefix,
@@ -69,7 +69,7 @@ echo "{$cursor->count()} contacts matching $name_prefix:\n";
 while ($cursor->hasNext())
 {
     $contact = $cursor->next();
-    echo "{$contact->name} {$contact->phone_number} {$contact->vars->birthdate}\n";        
+    echo "{$contact->name} {$contact->phone_number} {$contact->vars->birthdate}\n";
 }
 
 // Import a contact
@@ -82,6 +82,6 @@ $contact = $project->getOrCreateContact(array(
     )
 ));
 
-// Add a contact to a group    
+// Add a contact to a group
 $group = $project->getOrCreateGroup('Subscribers');
 $contact->addToGroup($group);

--- a/lib/broadcast.php
+++ b/lib/broadcast.php
@@ -144,6 +144,13 @@
           * Custom variables stored for this broadcast
           * Read-only
       
+      - route_params (associative array)
+          * Route-specific parameters for the messages in the broadcast. The parameters object
+              may have keys matching the `phone_type` field of a phone (basic route) that may be
+              used to send messages in this broadcast. The corresponding value is an object with
+              route-specific parameters to use when sending messages with that type of route.
+          * Read-only
+      
       - price (number)
           * The total price of all messages in this broadcast, if known.
           * Read-only

--- a/lib/contact.php
+++ b/lib/contact.php
@@ -159,7 +159,7 @@ class Telerivet_Contact extends Telerivet_Entity
             - status
                 * Filter messages by status
                 * Allowed values: ignored, processing, received, sent, queued, failed,
-                    failed_queued, cancelled, delivered, not_delivered
+                    failed_queued, cancelled, delivered, not_delivered, read
             
             - time_created[min] (UNIX timestamp)
                 * Filter messages created on or after a particular time
@@ -169,18 +169,26 @@ class Telerivet_Contact extends Telerivet_Entity
             
             - external_id
                 * Filter messages by ID from an external provider
+                * Allowed modifiers: external_id[ne], external_id[exists]
             
             - contact_id
                 * ID of the contact who sent/received the message
+                * Allowed modifiers: contact_id[ne], contact_id[exists]
             
             - phone_id
                 * ID of the phone (basic route) that sent/received the message
             
             - broadcast_id
                 * ID of the broadcast containing the message
+                * Allowed modifiers: broadcast_id[ne], broadcast_id[exists]
             
             - scheduled_id
                 * ID of the scheduled message that created this message
+                * Allowed modifiers: scheduled_id[ne], scheduled_id[exists]
+            
+            - group_id
+                * Filter messages sent or received by contacts in a particular group. The group must
+                    be a normal group, not a dynamic group.
             
             - sort
                 * Sort the results based on a field
@@ -265,16 +273,15 @@ class Telerivet_Contact extends Telerivet_Entity
             
             - time_created (UNIX timestamp)
                 * Filter scheduled messages by time_created
-                * Allowed modifiers: time_created[ne], time_created[min], time_created[max]
+                * Allowed modifiers: time_created[min], time_created[max]
             
             - next_time (UNIX timestamp)
                 * Filter scheduled messages by next_time
-                * Allowed modifiers: next_time[ne], next_time[min], next_time[max],
-                    next_time[exists]
+                * Allowed modifiers: next_time[min], next_time[max], next_time[exists]
             
             - sort
                 * Sort the results based on a field
-                * Allowed values: default, name
+                * Allowed values: default, next_time
                 * Default: default
             
             - sort_dir
@@ -308,7 +315,7 @@ class Telerivet_Contact extends Telerivet_Entity
             
             - time_created (UNIX timestamp)
                 * Filter data rows by the time they were created
-                * Allowed modifiers: time_created[ne], time_created[min], time_created[max]
+                * Allowed modifiers: time_created[min], time_created[max]
             
             - sort
                 * Sort the results based on a field

--- a/lib/datatable.php
+++ b/lib/datatable.php
@@ -58,7 +58,7 @@ class Telerivet_DataTable extends Telerivet_Entity
             
             - time_created (UNIX timestamp)
                 * Filter data rows by the time they were created
-                * Allowed modifiers: time_created[ne], time_created[min], time_created[max]
+                * Allowed modifiers: time_created[min], time_created[max]
             
             - contact_id
                 * Filter data rows associated with a particular contact

--- a/lib/entity.php
+++ b/lib/entity.php
@@ -1,45 +1,45 @@
 <?php
 /*
     Base class for all entities returned by the Telerivet API, including projects,
-    contacts, messages, groups, labels, scheduled messages, data tables, and data rows.       
- */ 
- 
+    contacts, messages, groups, labels, scheduled messages, data tables, and data rows.
+ */
+
 abstract class Telerivet_Entity
 {
     protected $_is_loaded;
     protected $_data;
     protected $_api;
     protected $_vars;
-    
+
     protected $_dirty = array();
-    
+
     function __construct($api, $data, $is_loaded = true)
     {
         $this->_api = $api;
         $this->_setData($data);
         $this->_is_loaded = $is_loaded;
     }
-    
+
     protected function _setData($data)
     {
         $this->_data = $data;
-        $this->_vars = new Telerivet_CustomVars(isset($data['vars']) ? $data['vars'] : array());        
+        $this->_vars = new Telerivet_CustomVars(isset($data['vars']) ? $data['vars'] : array());
     }
-     
+
     function load()
     {
         if (!$this->_is_loaded)
         {
             $this->_is_loaded = true;
             $old_dirty_vars = $this->_vars->getDirtyVariables();
-            
+
             $this->_setData($this->_api->doRequest('GET', $this->getBaseApiPath()));
-            
+
             foreach ($old_dirty_vars as $name => $value)
             {
                 $this->_vars->set($name, $value);
             }
-            
+
             foreach ($this->_dirty as $name => $value)
             {
                 $this->_data[$name] = $value;
@@ -47,7 +47,7 @@ abstract class Telerivet_Entity
         }
         return $this;
     }
-        
+
     function __get($name)
     {
         if ($name == 'vars')
@@ -55,7 +55,7 @@ abstract class Telerivet_Entity
             $this->load();
             return $this->_vars;
         }
-    
+
         $data = $this->_data;
         if (isset($data[$name]))
         {
@@ -68,41 +68,41 @@ abstract class Telerivet_Entity
 
         $this->load();
         $data = $this->_data;
-        
+
         return isset($data[$name]) ? $data[$name] : null;
     }
-    
+
     function __set($name, $value)
     {
-        $this->_data[$name] = $value;        
-        $this->_dirty[$name] = $value;        
+        $this->_data[$name] = $value;
+        $this->_dirty[$name] = $value;
     }
-    
+
     /**
      * Saves any updated properties to Telerivet.
      */
     function save()
     {
-        $dirty_props = $this->_dirty; 
+        $dirty_props = $this->_dirty;
 
         if ($this->_vars)
-        {   
+        {
             $dirty_vars = $this->_vars->getDirtyVariables();
             if ($dirty_vars)
             {
                 $dirty_props['vars'] = $dirty_vars;
             }
         }
-        
-        $this->_api->doRequest('POST', $this->getBaseApiPath(), $dirty_props);        
+
+        $this->_api->doRequest('POST', $this->getBaseApiPath(), $dirty_props);
         $this->_dirty = array();
-        
+
         if ($this->_vars)
         {
             $this->_vars->clearDirtyVariables();
         }
     }
-    
+
     function __toString()
     {
         $res = get_class($this);
@@ -111,10 +111,10 @@ abstract class Telerivet_Entity
             $res .= " (not loaded)";
         }
         $res .= " JSON: " . json_encode($this->_data);
-        
+
         return $res;
     }
-    
+
     abstract function getBaseApiPath();
 }
 
@@ -127,73 +127,73 @@ class Telerivet_CustomVars implements Iterator
     {
         $this->_vars = $vars;
     }
-    
+
     function all()
     {
         return $this->_vars;
     }
-    
+
     function getDirtyVariables()
     {
         return $this->_dirty;
     }
-    
+
     function clearDirtyVariables()
     {
         $this->_dirty = array();
-    }   
-    
-    function rewind() 
-    {
-        return reset($this->_vars);
     }
-  
-    function current() 
+
+    function rewind(): void
+    {
+        reset($this->_vars);
+    }
+
+    function current(): mixed
     {
         return current($this->_vars);
     }
-    
-    function key() 
+
+    function key(): mixed
     {
         return key($this->_vars);
     }
-  
-    function next() 
+
+    function next(): void
     {
-        return next($this->_vars);
+        next($this->_vars);
     }
-  
-    function valid() 
+
+    function valid(): bool
     {
         return key($this->_vars) !== null;
     }
-    
+
     function __isset($name)
     {
         return isset($this->_vars[$name]);
     }
-    
+
     function __unset($name)
     {
         unset($this->_vars[$name]);
     }
-    
+
     function get($name)
     {
         return isset($this->_vars[$name]) ? $this->_vars[$name] : null;
     }
-    
+
     function __get($name)
     {
         return $this->get($name);
     }
-    
+
     function set($name, $value)
     {
         $this->_vars[$name] = $value;
         $this->_dirty[$name] = $value;
     }
-    
+
     function __set($name, $value)
     {
         $this->set($name, $value);

--- a/lib/group.php
+++ b/lib/group.php
@@ -73,24 +73,22 @@ class Telerivet_Group extends Telerivet_Entity
             
             - time_created (UNIX timestamp)
                 * Filter contacts by time created
-                * Allowed modifiers: time_created[ne], time_created[min], time_created[max]
+                * Allowed modifiers: time_created[min], time_created[max]
             
             - last_message_time (UNIX timestamp)
                 * Filter contacts by last time a message was sent or received
-                * Allowed modifiers: last_message_time[ne], last_message_time[min],
-                    last_message_time[max], last_message_time[exists]
+                * Allowed modifiers: last_message_time[min], last_message_time[max],
+                    last_message_time[exists]
             
             - last_incoming_message_time (UNIX timestamp)
                 * Filter contacts by last time a message was received
-                * Allowed modifiers: last_incoming_message_time[ne],
-                    last_incoming_message_time[min], last_incoming_message_time[max],
-                    last_incoming_message_time[exists]
+                * Allowed modifiers: last_incoming_message_time[min],
+                    last_incoming_message_time[max], last_incoming_message_time[exists]
             
             - last_outgoing_message_time (UNIX timestamp)
                 * Filter contacts by last time a message was sent
-                * Allowed modifiers: last_outgoing_message_time[ne],
-                    last_outgoing_message_time[min], last_outgoing_message_time[max],
-                    last_outgoing_message_time[exists]
+                * Allowed modifiers: last_outgoing_message_time[min],
+                    last_outgoing_message_time[max], last_outgoing_message_time[exists]
             
             - incoming_message_count (int)
                 * Filter contacts by number of messages received from the contact
@@ -151,16 +149,15 @@ class Telerivet_Group extends Telerivet_Entity
             
             - time_created (UNIX timestamp)
                 * Filter scheduled messages by time_created
-                * Allowed modifiers: time_created[ne], time_created[min], time_created[max]
+                * Allowed modifiers: time_created[min], time_created[max]
             
             - next_time (UNIX timestamp)
                 * Filter scheduled messages by next_time
-                * Allowed modifiers: next_time[ne], next_time[min], next_time[max],
-                    next_time[exists]
+                * Allowed modifiers: next_time[min], next_time[max], next_time[exists]
             
             - sort
                 * Sort the results based on a field
-                * Allowed values: default, name
+                * Allowed values: default, next_time
                 * Default: default
             
             - sort_dir

--- a/lib/label.php
+++ b/lib/label.php
@@ -71,7 +71,7 @@ class Telerivet_Label extends Telerivet_Entity
             - status
                 * Filter messages by status
                 * Allowed values: ignored, processing, received, sent, queued, failed,
-                    failed_queued, cancelled, delivered, not_delivered
+                    failed_queued, cancelled, delivered, not_delivered, read
             
             - time_created[min] (UNIX timestamp)
                 * Filter messages created on or after a particular time
@@ -81,18 +81,26 @@ class Telerivet_Label extends Telerivet_Entity
             
             - external_id
                 * Filter messages by ID from an external provider
+                * Allowed modifiers: external_id[ne], external_id[exists]
             
             - contact_id
                 * ID of the contact who sent/received the message
+                * Allowed modifiers: contact_id[ne], contact_id[exists]
             
             - phone_id
                 * ID of the phone (basic route) that sent/received the message
             
             - broadcast_id
                 * ID of the broadcast containing the message
+                * Allowed modifiers: broadcast_id[ne], broadcast_id[exists]
             
             - scheduled_id
                 * ID of the scheduled message that created this message
+                * Allowed modifiers: scheduled_id[ne], scheduled_id[exists]
+            
+            - group_id
+                * Filter messages sent or received by contacts in a particular group. The group must
+                    be a normal group, not a dynamic group.
             
             - sort
                 * Sort the results based on a field

--- a/lib/message.php
+++ b/lib/message.php
@@ -19,7 +19,7 @@
       - status
           * Current status of the message
           * Allowed values: ignored, processing, received, sent, queued, failed, failed_queued,
-              cancelled, delivered, not_delivered
+              cancelled, delivered, not_delivered, read
           * Read-only
       
       - message_type
@@ -70,6 +70,13 @@
       
       - label_ids (array)
           * List of IDs of labels applied to this message
+          * Read-only
+      
+      - route_params (associative array)
+          * Route-specific parameters for the message. The parameters object may have keys
+              matching the `phone_type` field of a phone (basic route) that may be used to send the
+              message. The corresponding value is an object with route-specific parameters to use
+              when the message is sent by that type of route.
           * Read-only
       
       - vars (associative array)
@@ -139,12 +146,12 @@
       
       - short_urls (array)
           * For text messages containing short URLs, this is an array of objects with the
-              properties `short_url`, `link_type`, and `time_clicked` (the first time that URL was
-              clicked). If `link_type` is "redirect", the object also contains a `destination_url`
-              property. If `link_type` is "media", the object also contains an `media_index`
-              property (the index in the media array). If `link_type` is "service", the object also
-              contains a `service_id` property. This property is undefined for messages that do not
-              contain short URLs.
+              properties `short_url`, `link_type`, `time_clicked` (the first time that URL was
+              clicked), and `expiration_time`. If `link_type` is "redirect", the object also
+              contains a `destination_url` property. If `link_type` is "media", the object also
+              contains an `media_index` property (the index in the media array). If `link_type` is
+              "service", the object also contains a `service_id` property. This property is
+              undefined for messages that do not contain short URLs.
           * Read-only
       
       - media (array)

--- a/lib/phone.php
+++ b/lib/phone.php
@@ -142,7 +142,7 @@ class Telerivet_Phone extends Telerivet_Entity
             - status
                 * Filter messages by status
                 * Allowed values: ignored, processing, received, sent, queued, failed,
-                    failed_queued, cancelled, delivered, not_delivered
+                    failed_queued, cancelled, delivered, not_delivered, read
             
             - time_created[min] (UNIX timestamp)
                 * Filter messages created on or after a particular time
@@ -152,18 +152,26 @@ class Telerivet_Phone extends Telerivet_Entity
             
             - external_id
                 * Filter messages by ID from an external provider
+                * Allowed modifiers: external_id[ne], external_id[exists]
             
             - contact_id
                 * ID of the contact who sent/received the message
+                * Allowed modifiers: contact_id[ne], contact_id[exists]
             
             - phone_id
                 * ID of the phone (basic route) that sent/received the message
             
             - broadcast_id
                 * ID of the broadcast containing the message
+                * Allowed modifiers: broadcast_id[ne], broadcast_id[exists]
             
             - scheduled_id
                 * ID of the scheduled message that created this message
+                * Allowed modifiers: scheduled_id[ne], scheduled_id[exists]
+            
+            - group_id
+                * Filter messages sent or received by contacts in a particular group. The group must
+                    be a normal group, not a dynamic group.
             
             - sort
                 * Sort the results based on a field

--- a/lib/project.php
+++ b/lib/project.php
@@ -98,10 +98,30 @@ class Telerivet_Project extends Telerivet_Entity
                     short URLs.
                 * Default: false
             
+            - short_link_params (associative array)
+                *
+                    If `track_clicks` is true, `short_link_params` may be used to specify
+                    custom parameters for each short link in the message. The following parameters are
+                    supported:
+                    
+                    `domain` (string): A custom short domain name to use for the short
+                    links. The domain name must already be registered for your project or organization.
+                    
+                    `expiration_sec` (integer): The number of seconds after the message is
+                    created (queued to send) when the short links will stop forwarding to the
+                    destination URL.
+                    If null, the short links will not expire.
+            
             - media_urls (array)
                 * URLs of media files to attach to the text message. If `message_type` is `sms`,
                     short links to each media URL will be appended to the end of the content (separated
                     by a new line).
+            
+            - route_params (associative array)
+                * Route-specific parameters for the message. The parameters object should have one
+                    or more keys matching the `phone_type` field of a phone (basic route) that may be
+                    used to send the message. The corresponding value should be an object with
+                    route-specific parameters to use if the message is sent by that type of route.
             
             - label_ids (array)
                 * List of IDs of labels to add to this message
@@ -237,6 +257,20 @@ class Telerivet_Project extends Telerivet_Entity
                     short URLs.
                 * Default: false
             
+            - short_link_params (associative array)
+                *
+                    If `track_clicks` is true, `short_link_params` may be used to specify
+                    custom parameters for each short link in the message. The following parameters are
+                    supported:
+                    
+                    `domain` (string): A custom short domain name to use for the short
+                    links. The domain name must already be registered for your project or organization.
+                    
+                    `expiration_sec` (integer): The number of seconds after the message is
+                    created (queued to send) when the short links will stop forwarding to the
+                    destination URL.
+                    If null, the short links will not expire.
+            
             - is_template (bool)
                 * Set to true to evaluate variables like [[contact.name]] in message content
                 * Default: false
@@ -245,6 +279,12 @@ class Telerivet_Project extends Telerivet_Entity
                 * URLs of media files to attach to the text message. If `message_type` is `sms`,
                     short links to each media URL will be appended to the end of the content (separated
                     by a new line).
+            
+            - route_params (associative array)
+                * Route-specific parameters to use when sending the message. The parameters object
+                    may have keys matching the `phone_type` field of a phone (basic route) that may be
+                    used to send the message. The corresponding value is an object with route-specific
+                    parameters to use when sending a message with that type of route.
             
             - label_ids (array)
                 * Array of IDs of labels to add to the sent messages (maximum 5). Does not apply
@@ -415,6 +455,20 @@ class Telerivet_Project extends Telerivet_Entity
                     short URLs.
                 * Default: false
             
+            - short_link_params (associative array)
+                *
+                    If `track_clicks` is true, `short_link_params` may be used to specify
+                    custom parameters for each short link in the message. The following parameters are
+                    supported:
+                    
+                    `domain` (string): A custom short domain name to use for the short
+                    links. The domain name must already be registered for your project or organization.
+                    
+                    `expiration_sec` (integer): The number of seconds after the message is
+                    created (queued to send) when the short links will stop forwarding to the
+                    destination URL.
+                    If null, the short links will not expire.
+            
             - media_urls (array)
                 * URLs of media files to attach to the text message. If `message_type` is `sms`,
                     short links to each URL will be appended to the end of the content (separated by a
@@ -422,6 +476,12 @@ class Telerivet_Project extends Telerivet_Entity
             
             - vars (associative array)
                 * Custom variables to set for each message
+            
+            - route_params (associative array)
+                * Route-specific parameters for the messages in the broadcast. The parameters object
+                    may have keys matching the `phone_type` field of a phone (basic route) that may be
+                    used to send messages in this broadcast. The corresponding value is an object with
+                    route-specific parameters to use when sending messages with that type of route.
             
             - service_id
                 * Service to invoke for each recipient (when `message_type` is `call` or `service`)
@@ -510,10 +570,35 @@ class Telerivet_Project extends Telerivet_Entity
                     available variables)](#variables)
                 * Default: false
             
+            - track_clicks (boolean)
+                * If true, URLs in the message content will automatically be replaced with unique
+                    short URLs.
+                * Default: false
+            
+            - short_link_params (associative array)
+                *
+                    If `track_clicks` is true, `short_link_params` may be used to specify
+                    custom parameters for each short link in the message. The following parameters are
+                    supported:
+                    
+                    `domain` (string): A custom short domain name to use for the short
+                    links. The domain name must already be registered for your project or organization.
+                    
+                    `expiration_sec` (integer): The number of seconds after the message is
+                    created (queued to send) when the short links will stop forwarding to the
+                    destination URL.
+                    If null, the short links will not expire.
+            
             - media_urls (array)
                 * URLs of media files to attach to the text message. If `message_type` is `sms`,
                     short links to each media URL will be appended to the end of the content (separated
                     by a new line).
+            
+            - route_params (associative array)
+                * Route-specific parameters to apply to all messages. The parameters object may have
+                    keys matching the `phone_type` field of a phone (basic route) that may be used to
+                    send messages. The corresponding value is an object with route-specific parameters
+                    to use when sending messages with that type of route.
             
             - vars (associative array)
                 * Custom variables to store with the message
@@ -540,6 +625,10 @@ class Telerivet_Project extends Telerivet_Entity
                       (Other properties of the Message object are
                       omitted in order to reduce the amount of redundant data sent in each API
                       response.)
+                      If the `messages` parameter in the API request
+                      contains items with `to_number` values that are associated with blocked contacts,
+                      the `id` and `status` properties corresponding to those items will be null, and no
+                      messages will be sent to those numbers.
               
               - broadcast_id
                   * ID of broadcast that these messages are associated with, if `broadcast_id` or
@@ -715,24 +804,22 @@ class Telerivet_Project extends Telerivet_Entity
             
             - time_created (UNIX timestamp)
                 * Filter contacts by time created
-                * Allowed modifiers: time_created[ne], time_created[min], time_created[max]
+                * Allowed modifiers: time_created[min], time_created[max]
             
             - last_message_time (UNIX timestamp)
                 * Filter contacts by last time a message was sent or received
-                * Allowed modifiers: last_message_time[ne], last_message_time[min],
-                    last_message_time[max], last_message_time[exists]
+                * Allowed modifiers: last_message_time[min], last_message_time[max],
+                    last_message_time[exists]
             
             - last_incoming_message_time (UNIX timestamp)
                 * Filter contacts by last time a message was received
-                * Allowed modifiers: last_incoming_message_time[ne],
-                    last_incoming_message_time[min], last_incoming_message_time[max],
-                    last_incoming_message_time[exists]
+                * Allowed modifiers: last_incoming_message_time[min],
+                    last_incoming_message_time[max], last_incoming_message_time[exists]
             
             - last_outgoing_message_time (UNIX timestamp)
                 * Filter contacts by last time a message was sent
-                * Allowed modifiers: last_outgoing_message_time[ne],
-                    last_outgoing_message_time[min], last_outgoing_message_time[max],
-                    last_outgoing_message_time[exists]
+                * Allowed modifiers: last_outgoing_message_time[min],
+                    last_outgoing_message_time[max], last_outgoing_message_time[exists]
             
             - incoming_message_count (int)
                 * Filter contacts by number of messages received from the contact
@@ -836,8 +923,8 @@ class Telerivet_Project extends Telerivet_Entity
             
             - last_active_time (UNIX timestamp)
                 * Filter phones by last active time
-                * Allowed modifiers: last_active_time[ne], last_active_time[min],
-                    last_active_time[max], last_active_time[exists]
+                * Allowed modifiers: last_active_time[min], last_active_time[max],
+                    last_active_time[exists]
             
             - sort
                 * Sort the results based on a field
@@ -931,7 +1018,7 @@ class Telerivet_Project extends Telerivet_Entity
             - status
                 * Filter messages by status
                 * Allowed values: ignored, processing, received, sent, queued, failed,
-                    failed_queued, cancelled, delivered, not_delivered
+                    failed_queued, cancelled, delivered, not_delivered, read
             
             - time_created[min] (UNIX timestamp)
                 * Filter messages created on or after a particular time
@@ -941,18 +1028,26 @@ class Telerivet_Project extends Telerivet_Entity
             
             - external_id
                 * Filter messages by ID from an external provider
+                * Allowed modifiers: external_id[ne], external_id[exists]
             
             - contact_id
                 * ID of the contact who sent/received the message
+                * Allowed modifiers: contact_id[ne], contact_id[exists]
             
             - phone_id
                 * ID of the phone (basic route) that sent/received the message
             
             - broadcast_id
                 * ID of the broadcast containing the message
+                * Allowed modifiers: broadcast_id[ne], broadcast_id[exists]
             
             - scheduled_id
                 * ID of the scheduled message that created this message
+                * Allowed modifiers: scheduled_id[ne], scheduled_id[exists]
+            
+            - group_id
+                * Filter messages sent or received by contacts in a particular group. The group must
+                    be a normal group, not a dynamic group.
             
             - sort
                 * Sort the results based on a field
@@ -1175,8 +1270,16 @@ class Telerivet_Project extends Telerivet_Entity
                     <table>
                     <tr><td> `service_id` </td> <td> The ID of the
                     service to apply (string) </td></tr>
+                    <tr><td> `variables` </td> <td> Optional object
+                    containing up to 25 temporary variable names and their corresponding values to set
+                    when invoking the service. Values may be strings, numbers, or boolean (true/false).
+                    String values may be up to 4096 bytes in length. Arrays and objects are not
+                    supported. Within Custom Actions, each variable can be used like [[$name]] (with a
+                    leading $ character and surrounded by double square brackets). Within a Cloud Script
+                    API service or JavaScript action, each variable will be available as a global
+                    JavaScript variable like $name (with a leading $ character). (object) </td></tr>
                     </table>
-                    
+                    <br />
                     **`update_contact_var`**, **`update_message_var`**,
                     **`update_row_var`**:
                     <table>
@@ -1185,37 +1288,37 @@ class Telerivet_Project extends Telerivet_Entity
                     <tr><td> `value` </td> <td> The value to set
                     (string, boolean, float, null) </td></tr>
                     </table>
-                    
+                    <br />
                     **`add_group_members`**, **`remove_group_members`**:
                     <table>
                     <tr><td> `group_id` </td> <td> The ID of the group
                     (string) </td></tr>
                     </table>
-                    
+                    <br />
                     **`add_label`**, **`remove_label`**:
                     <table>
                     <tr><td> `label_id` </td> <td> The ID of the label
                     (string) </td></tr>
                     </table>
-                    
+                    <br />
                     **`resend_messages`**:
                     <table>
                     <tr><td> `route_id` </td> <td> ID of the new route
                     to use, or null to use the original route (string) </td></tr>
                     </table>
-                    
+                    <br />
                     **`set_send_blocked`**:
                     <table>
                     <tr><td> `send_blocked` </td> <td> `true` to block
                     sending messages, `false` to unblock sending messages (boolean) </td></tr>
                     </table>
-                    
+                    <br />
                     **`set_conversation_status`**:
                     <table>
                     <tr><td> `conversation_status` </td> <td> "active",
                     "handled", or "closed" (string) </td></tr>
                     </table>
-                    
+                    <br />
                     **`export_contacts`**, **`export_messages`**,
                     **`export_rows`**:
                     <table>
@@ -1239,7 +1342,7 @@ class Telerivet_Project extends Telerivet_Entity
                     save in the CSV file. If not provided, all default columns will be saved. (array of
                     strings, optional) </td></tr>
                     </table>
-                    
+                    <br />
                     **`delete_contacts`**, **`delete_messages`**,
                     **`delete_rows`**, **`cancel_messages`**, **`retry_message_services`**: <br />
                     No parameters.
@@ -1686,16 +1789,15 @@ class Telerivet_Project extends Telerivet_Entity
             
             - time_created (UNIX timestamp)
                 * Filter scheduled messages by time_created
-                * Allowed modifiers: time_created[ne], time_created[min], time_created[max]
+                * Allowed modifiers: time_created[min], time_created[max]
             
             - next_time (UNIX timestamp)
                 * Filter scheduled messages by next_time
-                * Allowed modifiers: next_time[ne], next_time[min], next_time[max],
-                    next_time[exists]
+                * Allowed modifiers: next_time[min], next_time[max], next_time[exists]
             
             - sort
                 * Sort the results based on a field
-                * Allowed values: default, name
+                * Allowed values: default, next_time
                 * Default: default
             
             - sort_dir

--- a/lib/scheduledmessage.php
+++ b/lib/scheduledmessage.php
@@ -135,6 +135,13 @@
               temporary and may not be valid for more than 1 day.
           * Read-only
       
+      - route_params (associative array)
+          * Route-specific parameters to use when sending the message. The parameters object may
+              have keys matching the `phone_type` field of a phone (basic route) that may be used to
+              send the message. The corresponding value is an object with route-specific parameters
+              to use when sending a message with that type of route.
+          * Read-only
+      
       - vars (associative array)
           * Custom variables stored for this scheduled message (copied to Message when sent)
           * Updatable via API

--- a/lib/service.php
+++ b/lib/service.php
@@ -121,6 +121,15 @@ class Telerivet_Service extends Telerivet_Entity
                     or `phone_number` is required if `context` is 'contact'). If no  contact exists with
                     this phone number, a new contact will be created.
             
+            - variables (associative array)
+                * Object containing up to 25 temporary variable names and their corresponding values
+                    to set when invoking the service. Values may be strings, numbers, or boolean
+                    (true/false). String values may be up to 4096 bytes in length. Arrays and objects
+                    are not supported. Within Custom Actions, each variable can be used like `[[$name]]`
+                    (with a leading `$` character and surrounded by double square brackets). Within a
+                    Cloud Script API service or JavaScript action, each variable will be available as a
+                    global JavaScript variable like `$name` (with a leading `$` character).
+            
             - route_id
                 * The ID of the phone or route that the service will use for sending messages by
                     default

--- a/telerivet.php
+++ b/telerivet.php
@@ -24,7 +24,7 @@ class Telerivet_API
     private $api_key;
     private $api_url;
     public $num_requests = 0;
-    private $client_version = '1.5.0';
+    private $client_version = '1.6.0';
 
     private $curl;
     public $debug = false;


### PR DESCRIPTION
Adds return types to Iterator functions to fix https://github.com/Telerivet/telerivet-php-client/issues/7 .

Note this also breaks compatibility with PHP 5 which doesn't support return types.

Updates comments to match latest documentation.